### PR TITLE
Explicitly specify plugins in prettier.format

### DIFF
--- a/.changeset/spotty-hornets-behave.md
+++ b/.changeset/spotty-hornets-behave.md
@@ -1,0 +1,5 @@
+---
+"@typespec-tools/emitter-typescript": patch
+---
+
+Allow running emitter in browser mode

--- a/packages/emitter-typescript/src/emitter.ts
+++ b/packages/emitter-typescript/src/emitter.ts
@@ -1,4 +1,6 @@
 import * as prettier from "prettier";
+import prettierPluginTypescript from "prettier/plugins/typescript";
+import prettierPluginEstree from "prettier/plugins/estree";
 import {
   BooleanLiteral,
   EmitContext,
@@ -415,6 +417,7 @@ export class TypescriptEmitter<
       emittedSourceFile.contents,
       {
         parser: "typescript",
+        plugins: [prettierPluginTypescript, prettierPluginEstree],
       }
     );
     return emittedSourceFile;


### PR DESCRIPTION
TypeSpec support running the compiler in browser mode, however when prettier is bundled in standalone mode for browser it requires listing all plugins explicitly:
https://github.com/prettier/prettier/issues/6264. This commit adds this to allow running it in browser.